### PR TITLE
Use Arrays.equals for equality in Matrix.java

### DIFF
--- a/src/main/java/com/backblaze/erasure/Matrix.java
+++ b/src/main/java/com/backblaze/erasure/Matrix.java
@@ -6,6 +6,8 @@
 
 package com.backblaze.erasure;
 
+import java.util.Arrays;
+
 /**
  * A matrix over the 8-bit Galois field.
  *
@@ -177,7 +179,7 @@ public class Matrix {
             return false;
         }
         for (int r = 0; r < rows; r++) {
-            if (!data[r].equals(((Matrix)other).data[r])) {
+            if (!Arrays.equals(data[r], ((Matrix)other).data[r])) {
                 return false;
             }
         }


### PR DESCRIPTION
This doesn't affect the tests, which use .toString() as a
proxy for equality, but it might affect users of the library
and causes one of my lint tools to complain.